### PR TITLE
Update PS module to 0.3.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore WpfApp
 
       - name: Sign files with Trusted Signing
-        uses: azure/trusted-signing-action@v0.3.0
+        uses: azure/trusted-signing-action@v0.3.15
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
         AZURE_USERNAME: ${{ inputs.azure-username }}
         AZURE_PASSWORD: ${{ inputs.azure-password }}
       run: |
-        Install-Module -Name TrustedSigning -RequiredVersion 0.3.8 -Force -Repository PSGallery
+        Install-Module -Name TrustedSigning -RequiredVersion 0.3.15 -Force -Repository PSGallery
 
         $params = @{}
 


### PR DESCRIPTION
This update will make the action use the latest version of Trusted Signing dlib and Windows SDK build tools.