### PR TITLE
Add file-digest's documented default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,7 @@ inputs:
   file-digest:
     description: The name of the digest algorithm used for hashing the files being signed (e.g. SHA256).
     required: false
+    default: 'SHA256'
   timestamp-rfc3161:
     description: A URL to an RFC3161 compliant timestamping service.
     required: false


### PR DESCRIPTION
There is no default to `file-digest`, despite the README specifying it. 