### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,7 @@ jobs:
     name: Build app and sign files with Trusted Signing
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 6.0.x
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: dotnet restore App


### PR DESCRIPTION
The nodejs 16 version used by checkout v3 will officially end support on September 11th.
More details here: https://github.com/actions/checkout/issues/1438

Also, FYI, the GitHub-hosted Windows runners come with .NET Core SDK 6.0.x pre-installed. 
Check out the specifics here:
	•	Windows 2019: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
	•	Windows 2022: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md