### PR TITLE
Updated actions/cache to v4.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -203,7 +203,7 @@ runs:
 
     - name: Cache TrustedSigning PowerShell module
       id: cache-module
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-module
       with:
@@ -213,7 +213,7 @@ runs:
   
     - name: Cache Microsoft.Windows.SDK.BuildTools NuGet package
       id: cache-buildtools
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-buildtools
       with:
@@ -223,7 +223,7 @@ runs:
 
     - name: Cache Microsoft.Trusted.Signing.Client NuGet package
       id: cache-tsclient
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-tsclient
       with:


### PR DESCRIPTION
This update silences the following error in the build logs:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.