### PR TITLE
Fix incorrect version reference in documentation for azure/trusted-signing-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore WpfApp
 
       - name: Sign files with Trusted Signing
-        uses: azure/trusted-signing-action@v0.4.1
+        uses: azure/trusted-signing-action@v0.4.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
This PR fixes the version reference in the documentation and example workflow from `v0.4.1` (which does not exist) to the correct version `v0.4.0`.

**Changes:**
- Updated all references to `azure/trusted-signing-action@v0.4.0`.

Closes #47 