### PR TITLE
Update OIDC.md

### DIFF
--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -13,6 +13,7 @@ Follow the steps below to authenticate with [Open ID Connect](https://www.micros
    1. Select 'Trusted Signing Certificate Profile Signer'.
    1. Next.
    1. Assign access to your 'User, group, or service principal' or 'Managed identity'.
+      1. **Note:** You will need to search for, and select, the service principal you created above. Only users will be listed by default.
    1. Review + assign.
 
 1. Adapt the following yaml to your GitHub pipeline:


### PR DESCRIPTION
Added an important note to the instructions when selecting the service principal. It can be confusing to folks who are not used to assigning roles that you must manually find the service principal.

Without knowing this ahead of time, you can accidentally select from the listed Users and not search for/select the Service Principal.