### PR TITLE
bump TRUSTED_SIGNING_NUGET_VERSION

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,7 @@ runs:
         
         "TRUSTED_SIGNING_MODULE_VERSION=0.5.3" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "BUILD_TOOLS_NUGET_VERSION=10.0.22621.3233" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "TRUSTED_SIGNING_NUGET_VERSION=1.0.53" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "TRUSTED_SIGNING_NUGET_VERSION=1.0.95" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.24469.1" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
     - name: Cache TrustedSigning PowerShell module


### PR DESCRIPTION
1.0.53 to latest
https://www.nuget.org/packages/Microsoft.Trusted.Signing.Client/1.0.95#versions-body-tab

FYI
>Trusted Signing: Upgrade tooling by 28 July 2025 to maintain support and functionality
You’re receiving this notification because you’re associated with one or more Azure subscriptions that use Trusted Signing.
Starting 28 July 2025, versions older than Microsoft.Trusted.Signing.Client 1.0.52 will no longer be supported.
Recommended action
Please upgrade your Trusted Signing tooling to the latest version before 28 July 2025. You can download the latest version here.
If you have additional questions, please reach out to us through the support channels.