### PR TITLE
docs: added clause indicating support for windows-2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Trusted Signing Action allows you to digitally sign your files using a Trust
 
 ## Runner Requirements
 This Action can only be executed on Windows runners. It is supported by the following GitHub hosted runners:
+- [windows-2025](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md)
 - [windows-2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)
 - [windows-2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md)
 


### PR DESCRIPTION
I've been testing my pipelines using the new windows 2025 images both internally and externally. And so far I've seen no issues. I think it would be advisable to include on the README the clause indicating that this action supports win 2025. 

As mentioned on Issue #88 