### PR TITLE
chore: update code owners  to artifact signing team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # see https://help.github.com/articles/about-codeowners
 
 # Default owner
-* @azure/trusted-signing-team
+* @azure/artifact-signing-team


### PR DESCRIPTION
The trusted signing team has been rebranded to the artifact signing team.