### PR TITLE
feat: check runner prior to execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -205,6 +205,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Check runner OS
+      shell: 'pwsh'
+      run: |
+        if ($env:RUNNER_OS -ne 'Windows') {
+          Write-Error "This action only supports Windows runners. Current runner OS: '$env:RUNNER_OS'."
+          exit 1
+        }
+
     - name: Set variables
       id: set-variables
       shell: 'pwsh'


### PR DESCRIPTION
This PR Resolves #76

Check which runner is running on the action and show a message indicating only windows is supported.
