### PR TITLE
docs: update examples to remove azps session

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          enable-AzPSSession: true
 
       - name: Sign files with Artifact Signing
         uses: azure/artifact-signing-action@v1

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -33,7 +33,6 @@ Follow the steps below to authenticate with [Open ID Connect](https://www.micros
               client-id: ${{ secrets.AZURE_CLIENT_ID }}
               tenant-id: ${{ secrets.AZURE_TENANT_ID }}
               subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-              enable-AzPSSession: true
 
           - name: Artifact Signing
             uses: azure/artifact-signing-action@v1


### PR DESCRIPTION
Given this [feedback](https://github.com/Azure/artifact-signing-action/issues/66#issuecomment-3888955104) we can remove this option from the examples provided.