### PR TITLE
refactor: migrate to new artifactsigning module

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -229,19 +229,19 @@ runs:
         $defaultPath = $env:PSModulePath -split ';' | Select-Object -First 1
         "PSMODULEPATH=$defaultPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         
-        "TRUSTED_SIGNING_MODULE_VERSION=0.5.8" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.4" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "BUILD_TOOLS_NUGET_VERSION=10.0.26100.4188" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "TRUSTED_SIGNING_NUGET_VERSION=1.0.95" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.25330.2" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "ARTIFACT_SIGNING_NUGET_VERSION=1.0.115" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.26179.1" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-    - name: Cache TrustedSigning PowerShell module
+    - name: Cache ArtifactSigning PowerShell module
       id: cache-module
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       env:
         cache-name: cache-module
       with:
-        path: ${{ steps.set-variables.outputs.PSMODULEPATH }}\TrustedSigning\${{ steps.set-variables.outputs.TRUSTED_SIGNING_MODULE_VERSION }}
-        key: TrustedSigning-${{ steps.set-variables.outputs.TRUSTED_SIGNING_MODULE_VERSION }}
+        path: ${{ steps.set-variables.outputs.PSMODULEPATH }}\ArtifactSigning\${{ steps.set-variables.outputs.ARTIFACT_SIGNING_MODULE_VERSION }}
+        key: ArtifactSigning-${{ steps.set-variables.outputs.ARTIFACT_SIGNING_MODULE_VERSION }}
       if: ${{ inputs.cache-dependencies == 'true' }}
   
     - name: Cache Microsoft.Windows.SDK.BuildTools NuGet package
@@ -250,18 +250,18 @@ runs:
       env:
         cache-name: cache-buildtools
       with:
-        path: ~\AppData\Local\TrustedSigning\Microsoft.Windows.SDK.BuildTools\Microsoft.Windows.SDK.BuildTools.${{ steps.set-variables.outputs.BUILD_TOOLS_NUGET_VERSION }}
+        path: ~\AppData\Local\ArtifactSigning\Microsoft.Windows.SDK.BuildTools\Microsoft.Windows.SDK.BuildTools.${{ steps.set-variables.outputs.BUILD_TOOLS_NUGET_VERSION }}
         key: Microsoft.Windows.SDK.BuildTools-${{ steps.set-variables.outputs.BUILD_TOOLS_NUGET_VERSION }}
       if: ${{ inputs.cache-dependencies == 'true' }}
 
-    - name: Cache Microsoft.Trusted.Signing.Client NuGet package
+    - name: Cache Microsoft.ArtifactSigning.Client NuGet package
       id: cache-tsclient
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       env:
         cache-name: cache-tsclient
       with:
-        path: ~\AppData\Local\TrustedSigning\Microsoft.Trusted.Signing.Client\Microsoft.Trusted.Signing.Client.${{ steps.set-variables.outputs.TRUSTED_SIGNING_NUGET_VERSION }}
-        key: Microsoft.Trusted.Signing.Client-${{ steps.set-variables.outputs.TRUSTED_SIGNING_NUGET_VERSION }}
+        path: ~\AppData\Local\ArtifactSigning\Microsoft.ArtifactSigning.Client\Microsoft.ArtifactSigning.Client.${{ steps.set-variables.outputs.ARTIFACT_SIGNING_NUGET_VERSION }}
+        key: Microsoft.ArtifactSigning.Client-${{ steps.set-variables.outputs.ARTIFACT_SIGNING_NUGET_VERSION }}
       if: ${{ inputs.cache-dependencies == 'true' }}
 
     - name: Cache SignCli NuGet package
@@ -270,14 +270,14 @@ runs:
       env:
         cache-name: cache-signcli
       with:
-        path: ~\AppData\Local\TrustedSigning\sign\sign.${{ steps.set-variables.outputs.DOTNET_SIGNCLI_NUGET_VERSION }}
+        path: ~\AppData\Local\ArtifactSigning\sign\sign.${{ steps.set-variables.outputs.DOTNET_SIGNCLI_NUGET_VERSION }}
         key: SignCli-${{ steps.set-variables.outputs.DOTNET_SIGNCLI_NUGET_VERSION }}
       if: ${{ inputs.cache-dependencies == 'true' }}
 
     - name: Install Artifact Signing module
       shell: 'pwsh'
       run: |
-        Install-Module -Name TrustedSigning -RequiredVersion ${{ steps.set-variables.outputs.TRUSTED_SIGNING_MODULE_VERSION }} -Force -Repository PSGallery
+        Install-Module -Name ArtifactSigning -RequiredVersion ${{ steps.set-variables.outputs.ARTIFACT_SIGNING_MODULE_VERSION }} -Force -Repository PSGallery
       if: ${{ inputs.cache-dependencies != 'true' || steps.cache-module.outputs.cache-hit != 'true' }}
 
     - name: Invoke signing
@@ -544,5 +544,5 @@ runs:
           $params["ClickOncePublisherName"] = $clickOncePublisherName
         }
 
-        Invoke-TrustedSigning @params
+        Invoke-ArtifactSigning @params
       shell: pwsh


### PR DESCRIPTION
This PR updates the trusted signing module to use the new artifact signing module.