### PR TITLE
refactor: upgrade packages to the latest versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -229,10 +229,10 @@ runs:
         $defaultPath = $env:PSModulePath -split ';' | Select-Object -First 1
         "PSMODULEPATH=$defaultPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         
-        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.4" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.6" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "BUILD_TOOLS_NUGET_VERSION=10.0.26100.4188" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "ARTIFACT_SIGNING_NUGET_VERSION=1.0.115" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.26179.1" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "ARTIFACT_SIGNING_NUGET_VERSION=1.0.128" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.26227.3" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
     - name: Cache ArtifactSigning PowerShell module
       id: cache-module

--- a/action.yml
+++ b/action.yml
@@ -229,7 +229,7 @@ runs:
         $defaultPath = $env:PSModulePath -split ';' | Select-Object -First 1
         "PSMODULEPATH=$defaultPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         
-        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.6" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.8" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "BUILD_TOOLS_NUGET_VERSION=10.0.26100.4188" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "ARTIFACT_SIGNING_NUGET_VERSION=1.0.128" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.26227.3" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
This PR updates the artifact signing powershell module, along with the signing tools of sign cli and the client dlib for signtool. The powershell module includes the fix for #124 . 

